### PR TITLE
feat: fecha fin to each requirement, improved loading states, improved date picker modal

### DIFF
--- a/neo-sync/app/(dashboard)/projects/[idProject]/proposal/ProposalComponent.tsx
+++ b/neo-sync/app/(dashboard)/projects/[idProject]/proposal/ProposalComponent.tsx
@@ -9,6 +9,7 @@ import Header from "@/components/global/Container/Header";
 import { Card, CardContent } from "@/components/ui/card";
 import DownloadProposal from "./DownloadProposal";
 import { Textarea } from "@/components/ui/textarea";
+import { Loader2 } from "lucide-react";
 
 interface ProjectInfo {
   nombre: string;
@@ -116,7 +117,19 @@ Fechas Importantes:
   };
 
   if (isLoading) {
-    return <div>Loading...</div>;
+    return (
+      <Container>
+        <Header title="Cargando propuesta...">
+          {/* Empty header while loading */}
+        </Header>
+        <Card className="mt-4">
+          <CardContent className="min-h-[600px] flex flex-col items-center justify-center space-y-4">
+            <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+            <p className="text-sm text-gray-400">Cargando propuesta del proyecto...</p>
+          </CardContent>
+        </Card>
+      </Container>
+    );
   }
 
   return (

--- a/neo-sync/components/custom/Alerts/CreateRequirement.tsx
+++ b/neo-sync/components/custom/Alerts/CreateRequirement.tsx
@@ -38,6 +38,7 @@ export function CreateRequirement({
     descripcion: "",
     tipo: "",
     fecha_inicio: undefined as Date | undefined,
+    fecha_fin: undefined as Date | undefined,
     esfuerzo_requerimiento: "",
     estatus: "todo",
   });
@@ -111,6 +112,9 @@ export function CreateRequirement({
       fecha_inicio: formData.fecha_inicio
         ? formData.fecha_inicio.toISOString().split("T")[0]
         : null,
+      fecha_fin: formData.fecha_fin
+        ? formData.fecha_fin.toISOString().split("T")[0]
+        : null,
     };
     console.log("Submitting requirement data:", submitData);
     await onSubmit(submitData);
@@ -120,7 +124,7 @@ export function CreateRequirement({
     <form onSubmit={handleSubmit}>
       <AlertDialogHeader>
         <AlertDialogTitle>Crear nuevo requerimiento</AlertDialogTitle>
-        <AlertDialogDescription>
+        <AlertDialogDescription className="overflow-visible">
           <div className="space-y-4 mt-4">
             <div>
               <label
@@ -152,39 +156,53 @@ export function CreateRequirement({
                 placeholder="Describe los detalles del requerimiento del proyecto"
               />
             </div>
-            <div className="flex gap-2">
-              <div className="w-1/2">
-                <label
-                  htmlFor="tipo"
-                  className="block text-sm font-medium text-gray-700"
-                >
-                  Tipo de requerimiento
-                </label>
-                <Select
-                  name="tipo"
-                  value={formData.tipo}
-                  onValueChange={handleSelectChange}
-                >
-                  <SelectTrigger id="tipo" className="w-full">
-                    <SelectValue placeholder="Seleccionar" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="RF">Funcional</SelectItem>
-                    <SelectItem value="RNF">No Funcional</SelectItem>
-                    <SelectItem value="otro">Otro</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+            <div>
+              <label
+                htmlFor="tipo"
+                className="block text-sm font-medium text-gray-700"
+              >
+                Tipo de requerimiento
+              </label>
+              <Select
+                name="tipo"
+                value={formData.tipo}
+                onValueChange={handleSelectChange}
+              >
+                <SelectTrigger id="tipo" className="w-full">
+                  <SelectValue placeholder="Seleccionar" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="RF">Funcional</SelectItem>
+                  <SelectItem value="RNF">No Funcional</SelectItem>
+                  <SelectItem value="otro">Otro</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="flex gap-4">
               <div className="w-1/2">
                 <label
                   htmlFor="fecha_inicio"
                   className="block text-sm font-medium text-gray-700"
                 >
-                  Fecha de inicio del proceso
+                  Fecha de inicio
                 </label>
                 <DatePicker
                   selectedDate={formData.fecha_inicio}
                   onDateChange={handleDateChange}
+                />
+              </div>
+              <div className="w-1/2">
+                <label
+                  htmlFor="fecha_fin"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Fecha de finalización
+                </label>
+                <DatePicker
+                  selectedDate={formData.fecha_fin}
+                  onDateChange={(date) => 
+                    setFormData(prev => ({ ...prev, fecha_fin: date }))
+                  }
                 />
               </div>
             </div>

--- a/neo-sync/components/custom/Overview/Kanban/Sheet/RequirementHeader.tsx
+++ b/neo-sync/components/custom/Overview/Kanban/Sheet/RequirementHeader.tsx
@@ -28,10 +28,11 @@ interface RequirementHeaderProps {
     nombre: string;
     tipo: "funcional" | "no funcional";
     fecha_inicio: string | null;
+    fecha_fin: string | null;
     estatus: string;
   };
   onUpdate: (updatedData: any) => void;
-  onClose?: () => void;  // Add this prop
+  onClose?: () => void;
 }
 
 export function RequirementHeader({ data, onUpdate, onClose }: RequirementHeaderProps) {
@@ -40,6 +41,9 @@ export function RequirementHeader({ data, onUpdate, onClose }: RequirementHeader
   const [tipo, setTipo] = useState(data.tipo);
   const [startDate, setStartDate] = useState<Date | undefined>(
     data.fecha_inicio ? new Date(data.fecha_inicio) : undefined
+  );
+  const [endDate, setEndDate] = useState<Date | undefined>(
+    data.fecha_fin ? new Date(data.fecha_fin) : undefined
   );
 
   const handleSave = async () => {
@@ -61,6 +65,7 @@ export function RequirementHeader({ data, onUpdate, onClose }: RequirementHeader
           nombre: nombre.trim(),
           tipo: tipo,
           fecha_inicio: startDate?.toISOString() || null,
+          fecha_fin: endDate?.toISOString() || null,
         })
         .eq("id", data.id);
 
@@ -71,6 +76,7 @@ export function RequirementHeader({ data, onUpdate, onClose }: RequirementHeader
         nombre: nombre.trim(),
         tipo: tipo,
         fecha_inicio: startDate?.toISOString() || null,
+        fecha_fin: endDate?.toISOString() || null,
       });
 
       toast({
@@ -93,6 +99,7 @@ export function RequirementHeader({ data, onUpdate, onClose }: RequirementHeader
     setNombre(data.nombre);
     setTipo(data.tipo);
     setStartDate(data.fecha_inicio ? new Date(data.fecha_inicio) : undefined);
+    setEndDate(data.fecha_fin ? new Date(data.fecha_fin) : undefined);
     setIsEditing(false);
   };
 
@@ -114,96 +121,134 @@ export function RequirementHeader({ data, onUpdate, onClose }: RequirementHeader
             )}
           </div>
 
+          {/* Reorganize the grid layout */}
           <div className="grid grid-cols-2 gap-4">
-            {/* Left Column: Type */}
-            <div className="space-y-1">
-              <p className="font-semibold">Tipo de requerimiento</p>
-              {isEditing ? (
-                <Select
-                  value={tipo}
-                  onValueChange={(value) =>
-                    setTipo(value as "funcional" | "no funcional")
-                  }
-                >
-                  <SelectTrigger className="w-[180px]">
-                    <SelectValue placeholder="Seleccionar tipo" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="funcional">Funcional</SelectItem>
-                    <SelectItem value="no funcional">No funcional</SelectItem>
-                  </SelectContent>
-                </Select>
-              ) : (
-                <p className="text-sm text-muted-foreground capitalize">
-                  {tipo}
-                </p>
-              )}
+            {/* Left Column: Type and Start Date */}
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <p className="font-semibold">Tipo de requerimiento</p>
+                {isEditing ? (
+                  <Select
+                    value={tipo}
+                    onValueChange={(value) =>
+                      setTipo(value as "funcional" | "no funcional")
+                    }
+                  >
+                    <SelectTrigger className="w-[180px]">
+                      <SelectValue placeholder="Seleccionar tipo" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="funcional">Funcional</SelectItem>
+                      <SelectItem value="no funcional">No funcional</SelectItem>
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <p className="text-sm text-muted-foreground capitalize">
+                    {tipo}
+                  </p>
+                )}
+              </div>
+
+              <div className="space-y-1">
+                <p className="font-semibold">Fecha de inicio</p>
+                {isEditing ? (
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        size={"sm"}
+                        variant={"outline"}
+                        className={cn(
+                          "w-[200px] h-8 justify-start text-left font-normal",
+                          !startDate && "text-muted-foreground"
+                        )}
+                      >
+                        <CalendarIcon className="mr-2 h-4 w-4" />
+                        {startDate
+                          ? format(startDate, "PPP")
+                          : "Seleccionar fecha"}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0">
+                      <Calendar
+                        mode="single"
+                        selected={startDate}
+                        onSelect={setStartDate}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    {startDate ? format(startDate, "PPP") : "No establecida"}
+                  </p>
+                )}
+              </div>
             </div>
 
-            {/* Right Column: Status */}
-            <div className="space-y-1">
-              <p className="font-semibold">Estado</p>
-              <p className="text-sm text-muted-foreground capitalize">
-                {data.estatus}
-              </p>
+            {/* Right Column: Status and End Date */}
+            <div className="space-y-4">
+              <div className="space-y-1">
+                <p className="font-semibold">Estado</p>
+                <p className="text-sm text-muted-foreground capitalize">
+                  {data.estatus}
+                </p>
+              </div>
+
+              <div className="space-y-1">
+                <p className="font-semibold">Fecha de finalización</p>
+                {isEditing ? (
+                  <Popover>
+                    <PopoverTrigger asChild>
+                      <Button
+                        size={"sm"}
+                        variant={"outline"}
+                        className={cn(
+                          "w-[200px] h-8 justify-start text-left font-normal",
+                          !endDate && "text-muted-foreground"
+                        )}
+                      >
+                        <CalendarIcon className="mr-2 h-4 w-4" />
+                        {endDate
+                          ? format(endDate, "PPP")
+                          : "Seleccionar fecha"}
+                      </Button>
+                    </PopoverTrigger>
+                    <PopoverContent className="w-auto p-0">
+                      <Calendar
+                        mode="single"
+                        selected={endDate}
+                        onSelect={setEndDate}
+                        initialFocus
+                      />
+                    </PopoverContent>
+                  </Popover>
+                ) : (
+                  <p className="text-sm text-muted-foreground">
+                    {endDate ? format(endDate, "PPP") : "No establecida"}
+                  </p>
+                )}
+              </div>
             </div>
           </div>
 
-          {/* Start Date and Edit Button Row */}
-          <div className="flex items-center justify-between">
-            <div className="space-y-1">
-              <p className="font-semibold">Fecha de inicio</p>
-              {isEditing ? (
-                <Popover>
-                  <PopoverTrigger asChild>
-                    <Button
-                      size={"sm"}
-                      variant={"outline"}
-                      className={cn(
-                        "w-[200px] h-8 justify-start text-left font-normal",
-                        !startDate && "text-muted-foreground"
-                      )}
-                    >
-                      <CalendarIcon className="mr-2 h-4 w-4" />
-                      {startDate
-                        ? format(startDate, "PPP")
-                        : "Seleccionar fecha"}
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0">
-                    <Calendar
-                      mode="single"
-                      selected={startDate}
-                      onSelect={setStartDate}
-                      initialFocus
-                    />
-                  </PopoverContent>
-                </Popover>
-              ) : (
-                <p className="text-sm text-muted-foreground capitalize">
-                  {startDate ? format(startDate, "PPP") : "No establecida"}
-                </p>
-              )}
-            </div>
-
-            {/* Edit/Save Buttons */}
-            <div className="flex space-x-2">
-              {isEditing ? (
-                <>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={handleCancel}
-                    className="h-8"
-                  >
-                    Cancelar
-                  </Button>
-                  <Button size="sm" onClick={handleSave}>
-                    Guardar
-                  </Button>
-                </>
-              ) : (
-                <>
+          {/* Edit/Save Buttons */}
+          <div className="flex justify-end space-x-2">
+            {isEditing ? (
+              <>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  onClick={handleCancel}
+                  className="h-8"
+                >
+                  Cancelar
+                </Button>
+                <Button size="sm" onClick={handleSave}>
+                  Guardar
+                </Button>
+              </>
+            ) : (
+              <>
                 <Button
                   size="icon"
                   onClick={() => setIsEditing(true)}
@@ -217,7 +262,6 @@ export function RequirementHeader({ data, onUpdate, onClose }: RequirementHeader
                 />
               </>
             )}
-            </div>
           </div>
         </div>
       </CardContent>

--- a/neo-sync/components/custom/Overview/Kanban/Sheet/TaskCardDrawer.tsx
+++ b/neo-sync/components/custom/Overview/Kanban/Sheet/TaskCardDrawer.tsx
@@ -15,6 +15,7 @@ interface RequirementData {
   nombre: string;
   tipo: "funcional" | "no funcional";
   fecha_inicio: string | null;
+  fecha_fin: string | null;
   estatus: string;
 }
 
@@ -49,7 +50,7 @@ export default function TaskCardDrawer({
           .single(),
         supabase
           .from("requerimiento")
-          .select("id, nombre, tipo, fecha_inicio, estatus")
+          .select("id, nombre, tipo, fecha_inicio, fecha_fin, estatus")
           .eq("id", requirementId)
           .single(),
       ]);

--- a/neo-sync/components/global/DatePicker.tsx
+++ b/neo-sync/components/global/DatePicker.tsx
@@ -8,7 +8,7 @@ import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Calendar } from "@/components/ui/calendar";
 import { Popover, PopoverTrigger } from "@/components/ui/popover";
-import { PopoverContent } from "@/components/ui/popoverDialog";
+import { PopoverContent } from "@/components/ui/popover";
 
 interface DatePickerProps {
   selectedDate: Date | undefined;
@@ -35,7 +35,12 @@ export function DatePicker({ selectedDate, onDateChange }: DatePickerProps) {
           )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0">
+      <PopoverContent 
+        align="start"
+        className="w-auto p-0" 
+        style={{ zIndex: 99999 }}
+        side="bottom"
+      >
         <Calendar
           mode="single"
           selected={selectedDate}


### PR DESCRIPTION
This pull request includes several updates to the `ProposalComponent.tsx`, `CreateRequirement.tsx`, `RequirementHeader.tsx`, `TaskCardDrawer.tsx`, and `DatePicker.tsx` files to enhance the user interface and add new functionality. The most important changes include the addition of a loading state with improved UI, the inclusion of an end date for requirements, and a reorganization of the RequirementHeader component layout.

### Enhancements to loading state:
* `neo-sync/app/(dashboard)/projects/[idProject]/proposal/ProposalComponent.tsx`: Added a `Loader2` spinner and updated the loading state UI to use `Container`, `Header`, and `Card` components for a more polished appearance. ([neo-sync/app/(dashboard)/projects/[idProject]/proposal/ProposalComponent.tsxR12](diffhunk://#diff-0e5f6eef2b48041e68dfeedd14a4b879cb6933ea619d45195e40f55ebc910269R12), [neo-sync/app/(dashboard)/projects/[idProject]/proposal/ProposalComponent.tsxL119-R132](diffhunk://#diff-0e5f6eef2b48041e68dfeedd14a4b879cb6933ea619d45195e40f55ebc910269L119-R132))

### Addition of end date for requirements:
* [`neo-sync/components/custom/Alerts/CreateRequirement.tsx`](diffhunk://#diff-ee17d125eed703e2dd4a805d3e1da6aa33112b6a68488c771be828d902f37379R41): Added `fecha_fin` (end date) to the form data, updated the form submission to include `fecha_fin`, and added a date picker for the end date. [[1]](diffhunk://#diff-ee17d125eed703e2dd4a805d3e1da6aa33112b6a68488c771be828d902f37379R41) [[2]](diffhunk://#diff-ee17d125eed703e2dd4a805d3e1da6aa33112b6a68488c771be828d902f37379R115-R117) [[3]](diffhunk://#diff-ee17d125eed703e2dd4a805d3e1da6aa33112b6a68488c771be828d902f37379R181-R207)
* [`neo-sync/components/custom/Overview/Kanban/Sheet/RequirementHeader.tsx`](diffhunk://#diff-a7fe0092d3b24bbaa59ce8883afbb65bfb88211698f2d598cef3f35efd4b31c4R31-R35): Added `fecha_fin` to the `RequirementHeader` state and updated the component to handle and display the end date. [[1]](diffhunk://#diff-a7fe0092d3b24bbaa59ce8883afbb65bfb88211698f2d598cef3f35efd4b31c4R31-R35) [[2]](diffhunk://#diff-a7fe0092d3b24bbaa59ce8883afbb65bfb88211698f2d598cef3f35efd4b31c4R45-R47) [[3]](diffhunk://#diff-a7fe0092d3b24bbaa59ce8883afbb65bfb88211698f2d598cef3f35efd4b31c4R68) [[4]](diffhunk://#diff-a7fe0092d3b24bbaa59ce8883afbb65bfb88211698f2d598cef3f35efd4b31c4R79) [[5]](diffhunk://#diff-a7fe0092d3b24bbaa59ce8883afbb65bfb88211698f2d598cef3f35efd4b31c4R102) [[6]](diffhunk://#diff-a7fe0092d3b24bbaa59ce8883afbb65bfb88211698f2d598cef3f35efd4b31c4R124-R127) [[7]](diffhunk://#diff-a7fe0092d3b24bbaa59ce8883afbb65bfb88211698f2d598cef3f35efd4b31c4L143-L153) [[8]](diffhunk://#diff-a7fe0092d3b24bbaa59ce8883afbb65bfb88211698f2d598cef3f35efd4b31c4L183-R235) [[9]](diffhunk://#diff-a7fe0092d3b24bbaa59ce8883afbb65bfb88211698f2d598cef3f35efd4b31c4L222)
* [`neo-sync/components/custom/Overview/Kanban/Sheet/TaskCardDrawer.tsx`](diffhunk://#diff-50783bea5cb632d017d829cb1dc8f402a96a866799f31396037283d59c1b7c40R18): Added `fecha_fin` to the requirement data fetched from the database. [[1]](diffhunk://#diff-50783bea5cb632d017d829cb1dc8f402a96a866799f31396037283d59c1b7c40R18) [[2]](diffhunk://#diff-50783bea5cb632d017d829cb1dc8f402a96a866799f31396037283d59c1b7c40L52-R53)

### UI improvements:
* [`neo-sync/components/custom/Alerts/CreateRequirement.tsx`](diffhunk://#diff-ee17d125eed703e2dd4a805d3e1da6aa33112b6a68488c771be828d902f37379L123-R127): Adjusted the form layout and styling for better visual consistency. [[1]](diffhunk://#diff-ee17d125eed703e2dd4a805d3e1da6aa33112b6a68488c771be828d902f37379L123-R127) [[2]](diffhunk://#diff-ee17d125eed703e2dd4a805d3e1da6aa33112b6a68488c771be828d902f37379L155-R159)
* [`neo-sync/components/global/DatePicker.tsx`](diffhunk://#diff-45e3bbb0d685949cb953e8d8538c746d8f1215d1e53d887552429026832092d6L11-R11): Fixed the import path for `PopoverContent` and updated the `PopoverContent` styling to improve z-index and alignment. [[1]](diffhunk://#diff-45e3bbb0d685949cb953e8d8538c746d8f1215d1e53d887552429026832092d6L11-R11) [[2]](diffhunk://#diff-45e3bbb0d685949cb953e8d8538c746d8f1215d1e53d887552429026832092d6L38-R43)