### PR TITLE
fixed supabase/ssr config

### DIFF
--- a/neo-sync/components/custom/Config/Config.tsx
+++ b/neo-sync/components/custom/Config/Config.tsx
@@ -2,13 +2,16 @@ import { Users, columns } from "./columnsConfig";
 import { DataTable, TableSkeleton } from "../../global/data-table";
 import { fetchUsers } from "@/app/(dashboard)/projects/fetchUser";
 import { Toaster } from "@/components/ui/toaster";
-import { createClientComponentClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserClient } from '@supabase/ssr'
 import { useEffect, useState } from "react";
 
 export default function Config() {
   const [users, setUsers] = useState<Users[]>([]);
   const [tableKey, setTableKey] = useState(0); // Add this to force table rerenders
-  const supabase = createClientComponentClient();
+  const supabase = createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+  );
   const [isLoading, setIsLoading] = useState(true);
 
   //* Function to subscribe to real-time changes on supabase


### PR DESCRIPTION
This pull request includes changes to the `neo-sync/components/custom/Config/Config.tsx` file, specifically updating the Supabase client initialization. The most important change is the switch from using `createClientComponentClient` to `createBrowserClient` for Supabase client creation.

Changes to Supabase client initialization:

* [`neo-sync/components/custom/Config/Config.tsx`](diffhunk://#diff-1b3c48b92dfb4c3b7a92c68da6b081b39f2b35a00f34726b6b7dfd513041cbeaL5-R14): Replaced `createClientComponentClient` with `createBrowserClient` to initialize the Supabase client using environment variables `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY`.